### PR TITLE
Fixed nested comment parsing

### DIFF
--- a/src/tokparse.sml
+++ b/src/tokparse.sml
@@ -27,7 +27,8 @@ struct
 	    (SOME st, SOME ed) =>
 	    let
 		fun bcNest _   = try (string st) >> $contNest
-		and contNest _ = try (string ed return ()) <|> $bcNest <|> (anyChar >> $contNest) return ()
+		and contNest _ = try (string ed return ())
+                                 <|> ($bcNest <|> (anyChar return ())) >> $contNest
 		val bcU = try (string st) >> repeat (not (string ed) >> anyChar) >> string ed return ()
 	    in if Lang.nestedComments then $ bcNest else bcU
 	    end


### PR DESCRIPTION
Currently nested comment parsing seems to behave pretty much the same as parsing for comments which aren't supposed to be nested. To fix this I've made it so that after every recursive call to `bcNest` we require finishing the current comment with `contNest`. I also removed the redundant `return ()` at the end of `contNest`.

Cheers,
Danny
